### PR TITLE
Distinguish never-reported EquipmentOutputStatus (None) from idle (0)

### DIFF
--- a/aiosomecomfort/device.py
+++ b/aiosomecomfort/device.py
@@ -361,14 +361,22 @@ class Device(object):
         )
 
     @property
-    def equipment_output_status(self) -> str:
-        """The current equipment output status"""
-        if self._data["uiData"]["EquipmentOutputStatus"] in (0, None):
+    def equipment_output_status(self) -> str | None:
+        """The current equipment output status.
+
+        Returns ``None`` when the device never reports EquipmentOutputStatus
+        (the raw value is ``None``) and the fan is not running, so callers can
+        distinguish "unknown" from a genuine idle ("off") report. Some models
+        never send this field to the cloud API at all.
+        """
+        raw_status = self._data["uiData"]["EquipmentOutputStatus"]
+        if raw_status in (0, None):
             if self.fan_running:
                 return "fan"
-            else:
-                return "off"
-        return EQUIPMENT_OUTPUT_STATUS[self._data["uiData"]["EquipmentOutputStatus"]]
+            if raw_status is None:
+                return None
+            return "off"
+        return EQUIPMENT_OUTPUT_STATUS[raw_status]
 
     @property
     def outdoor_temperature(self) -> float | None:

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1,0 +1,54 @@
+"""Unit tests for aiosomecomfort.device.Device."""
+
+import unittest
+
+from aiosomecomfort.device import Device
+
+
+def _make_device(equipment_output_status, has_fan=False, fan_is_running=False):
+    """Build a Device with a minimal _data payload for property testing."""
+    device = Device(client=None, location=None)
+    device._data = {
+        "uiData": {"EquipmentOutputStatus": equipment_output_status},
+        "hasFan": has_fan,
+        "fanData": {"fanIsRunning": fan_is_running},
+    }
+    return device
+
+
+class TestEquipmentOutputStatus(unittest.TestCase):
+    """Tests for the equipment_output_status property."""
+
+    def test_never_reported_returns_none(self):
+        """A raw value of None (never reported) should return None, not "off"."""
+        device = _make_device(None)
+        self.assertIsNone(device.equipment_output_status)
+
+    def test_genuine_idle_returns_off(self):
+        """A raw value of 0 (genuinely idle) should still return "off"."""
+        device = _make_device(0)
+        self.assertEqual(device.equipment_output_status, "off")
+
+    def test_never_reported_with_fan_returns_fan(self):
+        """A running fan is a known state even when the raw value is None."""
+        device = _make_device(None, has_fan=True, fan_is_running=True)
+        self.assertEqual(device.equipment_output_status, "fan")
+
+    def test_idle_with_fan_returns_fan(self):
+        """A running fan while idle (raw 0) returns "fan"."""
+        device = _make_device(0, has_fan=True, fan_is_running=True)
+        self.assertEqual(device.equipment_output_status, "fan")
+
+    def test_heating(self):
+        """A raw value of 1 maps to "heat"."""
+        device = _make_device(1)
+        self.assertEqual(device.equipment_output_status, "heat")
+
+    def test_cooling(self):
+        """A raw value of 2 maps to "cool"."""
+        device = _make_device(2)
+        self.assertEqual(device.equipment_output_status, "cool")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

Some Honeywell TCC thermostat models never send `EquipmentOutputStatus` to the cloud API at all — the raw value stays `None`, not `0`. The current `equipment_output_status` property treats `None` (never reported) and `0` (genuinely idle/off) identically, both collapsing to `"off"`.

This makes it impossible for a caller (e.g. Home Assistant's `honeywell` integration) to distinguish "this device doesn't report run status" from "this device reports that it's idle." In practice it causes the HA thermostat card to show "Idle" even while the system is actively heating or cooling, for any model that doesn't populate this field. See home-assistant/core#176038 for a real-world report with diagnostics confirming `EquipmentOutputStatus: null` while the AC was actively running.

## Change

`equipment_output_status` now returns `None` when the raw value is `None` and the fan isn't running, instead of falling through to `"off"`. A device that explicitly reports `0` still returns `"off"` as before — this only changes behavior for devices that never send the field at all.

## Tests

Added `tests/test_device.py` with unit tests covering: never-reported → `None`, genuine idle (`0`) → `"off"`, never-reported-with-fan-running → `"fan"`, idle-with-fan-running → `"fan"`, and the existing heat/cool mappings. All pass locally (`pytest tests/test_device.py`), and `ruff check`/`ruff format --diff` are clean against this file (no new findings versus main).

## Related

- home-assistant/core#176038 (the original bug report)
- A workaround-in-HA-core PR (home-assistant/core#176043) is open but should become unnecessary once this lands and the honeywell integration bumps its `AIOSomeComfort` pin — happy to help with that follow-up once a release is cut.
